### PR TITLE
Deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A Bayesian CN Hyperfine Spectroscopy Model
 
+**This package is deprecated and no longer maintained. Instead, use [`bayes_hfs`](https://github.com/tvwenger/bayes_hfs), a general purpose model for molecular hyperfine spectroscopy.**
+
 `bayes_cn_hfs` implements models to infer the physics of the interstellar medium from hyperfine spectroscopy observations of CN as well as the carbon isotopic ratio from observations of CN and $^{13}$CN.
 
 - [Installation](#installation)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 bayes_cn_hfs
 ============
 
-**This package is deprecated and no longer maintained. Instead, use `bayes_hfs <https://github.com/tvwenger/bayes_hfs>`_, a general purpose model for molecular hyperfine spectroscopy.**
+NOTE: This package is deprecated and no longer maintained. Instead, use `bayes_hfs <https://github.com/tvwenger/bayes_hfs>`_, a general purpose model for molecular hyperfine spectroscopy.
 
 ``bayes_cn_hfs`` implements two models for molecular hyperfine spectroscopy. The first is ``CNModel``, which can model the emission of ``CN`` or ``13CN``.
 The second is ``CNRatioModel``, which predicts both ``CN`` and ``13CN`` observations in order to infer the ``12C/13C`` isotopic ratio. ``bayes_cn_hfs`` 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,8 @@
 bayes_cn_hfs
 ============
 
+**This package is deprecated and no longer maintained. Instead, use `bayes_hfs <https://github.com/tvwenger/bayes_hfs>`_, a general purpose model for molecular hyperfine spectroscopy.**
+
 ``bayes_cn_hfs`` implements two models for molecular hyperfine spectroscopy. The first is ``CNModel``, which can model the emission of ``CN`` or ``13CN``.
 The second is ``CNRatioModel``, which predicts both ``CN`` and ``13CN`` observations in order to infer the ``12C/13C`` isotopic ratio. ``bayes_cn_hfs`` 
 is written in the ``bayes_spec`` Bayesian modeling framework, which provides methods to fit these models to data using Monte Carlo Markov Chain techniques.


### PR DESCRIPTION
Deprecates `bayes_cn_hfs` in favor of `bayes_hfs`.